### PR TITLE
Migrate to Token-based Auth

### DIFF
--- a/app/context/WebSocketContext.tsx
+++ b/app/context/WebSocketContext.tsx
@@ -10,7 +10,7 @@ import React, {
   useCallback,
 } from "react";
 import useWebSocket, { ReadyState } from "react-use-websocket";
-import { getApiKey } from "../lib/helpers";
+import { getToken } from "../lib/helpers";
 import { useAuth } from "./Auth";
 import { systemContent } from "../lib/constants";
 
@@ -121,7 +121,7 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
   const { sendMessage, lastMessage, readyState, getWebSocket } = useWebSocket(
     socketURL,
     {
-      protocols: apiKey ? ["token", apiKey] : undefined,
+      protocols: apiKey ? ["bearer", apiKey] : undefined,
       share: true,
       onOpen: () => {
         console.log("WebSocket connection opened");
@@ -478,7 +478,7 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
     if (token) {
       const fetchApiKey = async () => {
         try {
-          const key = await getApiKey(token as string);
+          const key = await getToken(token as string);
           setApiKey(key);
         } catch (error) {
           console.error("Failed to fetch API key:", error);

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -1,7 +1,11 @@
-import { CreateProjectKeyResponse } from "@deepgram/sdk";
+interface TokenResponse {
+  key: string;
+  expires_in?: number;
+  url?: string;
+}
 
-const getApiKey = async (token: string): Promise<string> => {
-  const result: CreateProjectKeyResponse = await (
+const getToken = async (token: string): Promise<string> => {
+  const result: TokenResponse = await (
     await fetch("/api/authenticate", {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -13,4 +17,4 @@ const getApiKey = async (token: string): Promise<string> => {
   return result.key;
 };
 
-export { getApiKey };
+export { getToken };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@deepgram/sdk": "^3.2.0-alpha.1",
+    "@deepgram/sdk": "^4.1.1",
     "@fullstory/browser": "^2.0.3",
     "@next/third-parties": "^14.1.0",
     "@nextui-org/react": "^2.2.10",


### PR DESCRIPTION
The recommended Deepgram approach for client-side auth is Token-based Auth.

Now that this project supports `v1/agent/converse` it's just a matter of migrating to `/auth/grant` and ensuring we're using the right authorization header.

Docs: https://developers.deepgram.com/guides/fundamentals/token-based-authentication 